### PR TITLE
Make build script `cargo publish` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,14 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 build="build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-crate-type = ["cdylib"]
+# Create a dynamic library for C usage and a rust library so it can be called from rust
+crate-type = ["cdylib","lib"]
 
 [dependencies]
 libc = "0.2.62"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -43,8 +43,8 @@ pub struct randomx_vm {
     _unused: [u8; 0],
 }
 
-#[link(name = "c++", kind = "dylib")]
-#[link(name = "randomx", kind = "static")]
+//#[link(name = "c++", kind = "dylib")]
+//#[link(name = "randomx", kind = "static")]
 extern "C" {
     pub fn randomx_alloc_cache(flags: c_uint) -> *mut randomx_cache;
     pub fn randomx_init_cache(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ impl RandomXVM {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{RandomXCache, RandomXDataset, RandomXFlag, RandomXVM};
 
     #[test]
     fn lib_alloc_cache() {


### PR DESCRIPTION
* cargo publish fails becuase the source tree was being modified by the
   build script

* Bump patch number
