### PR TITLE
Drop ARCH=native

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -87,7 +87,6 @@ fn main() {
         assert!(m.status.success());
     } else {
         let c = Command::new("cmake")
-            .arg("-DARCH=native")
             .arg(".")
             .output()
             .expect("failed to execute CMake");


### PR DESCRIPTION
Stops the `Illegal Instruction` error when a different arch builds the lib, i.e. quay.io building the lib in Docker, and a MacBook being unable to run that docker image.