### PR TITLE
Critical Bug Fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 build="build.rs"
 


### PR DESCRIPTION
Found a bug where the hashes being generated between RandomX instances were not consistent even though the inputs were the same. Fixed it and added an additional test for this.

Modified crate to accept &[u8] instead of &[str], as well as to return Vec[u8] instead of String, to be consistent with other hashing crates.

Updated version to 0.3.0, since this is a breaking change.