### PR TITLE
Add partial_eq to random_X err

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl Default for RandomXFlag {
     }
 }
 
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, PartialEq)]
 /// Custom error enum
 pub enum RandomXError {
     /// Problem creating the RandomX object


### PR DESCRIPTION
Adds in PartialEq to RandomXError. 

This is required to add the error to the chain error of the base_node