### PR TITLE
Multithreaded dataset initialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 build="build.rs"
 
@@ -19,6 +19,7 @@ crate-type = ["cdylib","lib"]
 libc = "0.2.62"
 derive-error = "0.0.4"
 bitflags = "1.2.1"
+num_cpus = "1.13.0"
 
 [build-dependencies]
 git2 = "0.8"

--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,7 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
-    const RANDOMX_COMMIT: &str = "ac574e3743b00680445994cbe2c38ba0f52db70d";
+    const RANDOMX_COMMIT: &str = "5ce5f4906c1eb166be980f6d83cc80f4112ffc2a";
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let project_dir = Path::new(&out_dir);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -22,6 +22,7 @@
 extern crate libc;
 
 use libc::{c_uint, c_ulong, c_void};
+
 pub const RANDOMX_HASH_SIZE: u32 = 32;
 pub const RANDOMX_DATASET_ITEM_SIZE: u32 = 64;
 
@@ -31,11 +32,17 @@ pub struct randomx_dataset {
     _unused: [u8; 0],
 }
 
+unsafe impl Send for randomx_dataset {}
+unsafe impl Sync for randomx_dataset {}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct randomx_cache {
     _unused: [u8; 0],
 }
+
+unsafe impl Send for randomx_cache {}
+unsafe impl Sync for randomx_cache {}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR allows RandomX to be (optionally) initialized with multiple threads instead of just a single thread.

The code will  automatically detect the number of cores available on the machine and spawn that amount of non-overlapping threads (which can be limited to less) to initialize the dataset.

This is a performance improvement which is useful whenever a new RandomX VM is initialized.

Change log:
Updated commit hash of RandomX to latest version.
Added num_cpu dependency.
Impl Sync+Send for randomx_dataset and randomx_cache.
Added multithreaded initialization for RandomXDataset.
Bumped minor version.
Added tests.

@CjS77 Will need a release to crates.io