### PR TITLE
chore: update version to match RandomX version (1.1.9)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "RandomX"]
+	path = RandomX
+	url = https://github.com/tevador/RandomX.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "RandomX"]
-	path = RandomX
-	url = https://github.com/tevador/RandomX.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.5.1"
+version = "1.1.9"
 edition = "2018"
 build="build.rs"
 


### PR DESCRIPTION
Keeping the RandomX version the same as the submodule repo allows a user to simply see which version of RandomX is being used. If there are subtle changes, they can be added in the patch version (e.g. 1.1.9.2)