### PR TITLE
fix: use proper lifetimes for cache and dataset

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,23 +20,24 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use std::env;
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::fs;
-
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let project_dir = Path::new(&out_dir);
     let cargo_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let repo_dir = PathBuf::from(env::var("RANDOMX_DIR").unwrap_or_else(|_| format!("{}/RandomX", &cargo_dir)));
+    let repo_dir = PathBuf::from(
+        env::var("RANDOMX_DIR").unwrap_or_else(|_| format!("{}/RandomX", &cargo_dir)),
+    );
     let build_dir = &project_dir.join("randomx_build");
 
     env::set_current_dir(Path::new(&repo_dir)).unwrap(); //change current path to repo for dependency build
-    let _ = fs::create_dir(&build_dir);  // path might exist
-    env::set_current_dir(build_dir).unwrap();               
+    let _ = fs::create_dir(&build_dir); // path might exist
+    env::set_current_dir(build_dir).unwrap();
     let target = env::var("TARGET").unwrap();
     if target.contains("windows") {
         let c = Command::new("cmake")
@@ -92,7 +93,6 @@ fn main() {
         println!(
             "cargo:rustc-link-search=native={}",
             &build_dir.to_str().unwrap()
-
         );
         println!("cargo:rustc-link-lib=static=randomx");
     } //link to RandomX

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,9 @@ impl RandomXCache {
             ))
         } else {
             let inner = RandomXCacheInner { cache_ptr: test };
-            let result = RandomXCache { inner: Arc::new(inner) };
+            let result = RandomXCache {
+                inner: Arc::new(inner),
+            };
             let key_ptr = key.as_ptr() as *mut c_void;
             let key_size = key.len() as usize;
             unsafe {
@@ -315,22 +317,22 @@ impl RandomXVM {
     ) -> Result<RandomXVM, RandomXError> {
         let is_full_mem = flags.contains(RandomXFlag::FLAG_FULL_MEM);
         match (cache, dataset) {
-            (None, None) => {
-                Err(RandomXError::CreationError("Failed to allocate VM".to_string()))
-            }
-            (None, _) if !is_full_mem => {
-                Err(RandomXError::FlagConfigError(
-                    "No cache and FLAG_FULL_MEM not set".to_string(),
-                ))
-            }
-            (_, None) if is_full_mem => {
-                Err(RandomXError::FlagConfigError(
-                    "No dataset and FLAG_FULL_MEM set".to_string(),
-                ))
-            }
+            (None, None) => Err(RandomXError::CreationError(
+                "Failed to allocate VM".to_string(),
+            )),
+            (None, _) if !is_full_mem => Err(RandomXError::FlagConfigError(
+                "No cache and FLAG_FULL_MEM not set".to_string(),
+            )),
+            (_, None) if is_full_mem => Err(RandomXError::FlagConfigError(
+                "No dataset and FLAG_FULL_MEM set".to_string(),
+            )),
             (cache, dataset) => {
-                let cache_ptr = cache.map(|stash| stash.inner.cache_ptr).unwrap_or_else(ptr::null_mut);
-                let dataset_ptr = dataset.map(|data| data.inner.dataset_ptr).unwrap_or_else(ptr::null_mut);
+                let cache_ptr = cache
+                    .map(|stash| stash.inner.cache_ptr)
+                    .unwrap_or_else(ptr::null_mut);
+                let dataset_ptr = dataset
+                    .map(|data| data.inner.dataset_ptr)
+                    .unwrap_or_else(ptr::null_mut);
                 let vm = unsafe { randomx_create_vm(flags.bits, cache_ptr, dataset_ptr) };
                 Ok(RandomXVM {
                     vm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,7 +481,7 @@ mod tests {
         let key = "Key";
         let cache = RandomXCache::new(flags, key.as_bytes());
         if let Err(i) = cache {
-            panic!(format!("Failed to allocate cache, {}", i));
+            panic!("Failed to allocate cache, {}", i);
         }
         drop(cache);
     }
@@ -493,7 +493,7 @@ mod tests {
         let cache = RandomXCache::new(flags, key.as_bytes()).unwrap();
         let dataset = RandomXDataset::new(flags, &cache, 0);
         if let Err(i) = dataset {
-            panic!(format!("Failed to allocate dataset, {}", i));
+            panic!("Failed to allocate dataset, {}", i);
         }
         drop(dataset);
         drop(cache);
@@ -506,13 +506,13 @@ mod tests {
         let cache = RandomXCache::new(flags, key.as_bytes()).unwrap();
         let mut vm = RandomXVM::new(flags, Some(&cache), None);
         if let Err(i) = vm {
-            panic!(format!("Failed to allocate vm, {}", i));
+            panic!("Failed to allocate vm, {}", i);
         }
         drop(vm);
         let dataset = RandomXDataset::new(flags, &cache, 0).unwrap();
         vm = RandomXVM::new(flags, Some(&cache), Some(&dataset));
         if let Err(i) = vm {
-            panic!(format!("Failed to allocate vm, {}", i));
+            panic!("Failed to allocate vm, {}", i);
         }
         drop(dataset);
         drop(cache);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,4 +651,40 @@ mod tests {
         drop(dataset1);
         drop(cache1);
     }
+
+    #[test]
+    fn lib_check_cache_and_dataset_lifetimes() {
+        let flags = RandomXFlag::get_recommended_flags();
+        let key = "Key";
+        let input = "Input";
+        let cache = RandomXCache::new(flags, key.as_bytes()).unwrap();
+        let dataset = RandomXDataset::new(flags, &cache, 0).unwrap();
+        let vm = RandomXVM::new(flags, Some(&cache), Some(&dataset)).unwrap();
+        drop(dataset);
+        drop(cache);
+        let hash = vm.calculate_hash(input.as_bytes()).expect("no data");
+        assert_eq!(
+            hash,
+            [
+                114, 81, 192, 5, 165, 242, 107, 100, 184, 77, 37, 129, 52, 203, 217, 227, 65, 83,
+                215, 213, 59, 71, 32, 172, 253, 155, 204, 111, 183, 213, 157, 155
+            ]
+        );
+        drop(vm);
+
+        let cache1 = RandomXCache::new(flags, key.as_bytes()).unwrap();
+        let dataset1 = RandomXDataset::new(flags, &cache1, 0).unwrap();
+        let vm1 = RandomXVM::new(flags, Some(&cache1), Some(&dataset1)).unwrap();
+        drop(dataset1);
+        drop(cache1);
+        let hash1 = vm1.calculate_hash(input.as_bytes()).expect("no data");
+        assert_eq!(
+            hash1,
+            [
+                114, 81, 192, 5, 165, 242, 107, 100, 184, 77, 37, 129, 52, 203, 217, 227, 65, 83,
+                215, 213, 59, 71, 32, 172, 253, 155, 204, 111, 183, 213, 157, 155
+            ]
+        );
+        drop(vm1);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ pub struct RandomXDatasetInner {
     dataset_ptr: *mut randomx_dataset,
     dataset_start: c_ulong,
     dataset_count: c_ulong,
+    #[allow(dead_code)]
+    cache: RandomXCache,
 }
 
 impl Drop for RandomXDatasetInner {
@@ -216,6 +218,7 @@ impl RandomXDataset {
                 dataset_ptr: test,
                 dataset_start: start,
                 dataset_count: count,
+                cache: cache.clone(),
             };
             let result = RandomXDataset {
                 inner: Arc::new(inner),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,31 +323,33 @@ impl RandomXVM {
     /// Re-initializes the `VM` with a new cache that was initialised without
     /// RandomXFlag::FLAG_FULL_MEM.
     pub fn reinit_cache(&self, cache: &RandomXCache) -> Result<(), RandomXError> {
-        if self.flags & RandomXFlag::FLAG_FULL_MEM == RandomXFlag::FLAG_FULL_MEM {
-            return Err(RandomXError::FlagConfigError(
+        if !self.flags.contains(RandomXFlag::FLAG_FULL_MEM) {
+            //no way to check if this fails, c code does not return anything
+            unsafe {
+                randomx_vm_set_cache(self.vm, cache.cache);
+            }
+            Ok(())
+        } else {
+            Err(RandomXError::FlagConfigError(
                 "Cannot reinit cache with FLAG_FULL_MEM set".to_string(),
-            ));
+            ))
         }
-        //no way to check if this fails, c code does not return anything
-        unsafe {
-            randomx_vm_set_cache(self.vm, cache.cache);
-        }
-        Ok(())
     }
 
     /// Re-initializes the `VM` with a new dataset that was initialised with
     /// RandomXFlag::FLAG_FULL_MEM.
     pub fn reinit_dataset(&self, dataset: &RandomXDataset) -> Result<(), RandomXError> {
-        if self.flags & RandomXFlag::FLAG_FULL_MEM != RandomXFlag::FLAG_FULL_MEM {
-            return Err(RandomXError::FlagConfigError(
+        if self.flags.contains(RandomXFlag::FLAG_FULL_MEM) {
+            //no way to check if this fails, c code does not return anything
+            unsafe {
+                randomx_vm_set_dataset(self.vm, dataset.dataset);
+            }
+            Ok(())
+        } else {
+            Err(RandomXError::FlagConfigError(
                 "Cannot reinit dataset without FLAG_FULL_MEM set".to_string(),
-            ));
+            ))
         }
-        //no way to check if this fails, c code does not return anything
-        unsafe {
-            randomx_vm_set_dataset(self.vm, dataset.dataset);
-        }
-        Ok(())
     }
 
     /// Calculates a RandomX hash value and returns it, error on failure.


### PR DESCRIPTION
The PR wraps pointers to a cache and a dataset with `Arc` that let to track the lifetime of the objects properly.