### PR TITLE
build(fix): add env pass through for cmake_osx_sysroot

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -107,8 +107,7 @@ fn main() {
         std::io::stderr().write_all(&m.stderr).unwrap();
         assert!(m.status.success());
     } else if target.contains("aarch64-apple-darwin") {
-        if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
-            let c = Command::new("cmake")
+        let mut c = Command::new("cmake")
                 .arg("-D")
                 .arg("ARCH=arm64")
                 .arg("-D")
@@ -120,38 +119,19 @@ fn main() {
                 .arg("-D")
                 .arg("CMAKE_C_FLAGS='-arch arm64'")
                 .arg("-D")
-                .arg("CMAKE_CXX_FLAGS='-arch arm64'")
-                .arg("-D")
+                .arg("CMAKE_CXX_FLAGS='-arch arm64'");
+                if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
+                c = c.arg("-D")
                 .arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
-                .arg(repo_dir.to_str().unwrap())
+                };
+                c.arg(repo_dir.to_str().unwrap())
                 .output()
                 .expect("failed to execute CMake");
             println!("status: {}", c.status);
             std::io::stdout().write_all(&c.stdout).unwrap();
             std::io::stderr().write_all(&c.stderr).unwrap();
             assert!(c.status.success());
-        } else {
-            let c = Command::new("cmake")
-                .arg("-D")
-                .arg("ARCH=arm64")
-                .arg("-D")
-                .arg("ARCH_ID=aarch64")
-                .arg("-D")
-                .arg("CMAKE_CROSSCOMPILING=true")
-                .arg("-D")
-                .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
-                .arg("-D")
-                .arg("CMAKE_C_FLAGS='-arch arm64'")
-                .arg("-D")
-                .arg("CMAKE_CXX_FLAGS='-arch arm64'")
-                .arg(repo_dir.to_str().unwrap())
-                .output()
-                .expect("failed to execute CMake");
-            println!("status: {}", c.status);
-            std::io::stdout().write_all(&c.stdout).unwrap();
-            std::io::stderr().write_all(&c.stderr).unwrap();
-            assert!(c.status.success());
-        }
+    
 
         let m = Command::new("cmake")
             .arg("--build")

--- a/build.rs
+++ b/build.rs
@@ -45,8 +45,12 @@ fn main() {
         },
     }
     env::set_current_dir(build_dir).unwrap();
+
+    let host = env::var("HOST").unwrap();
+    //println!("host: {}", host);
     let target = env::var("TARGET").unwrap();
-    if target.contains("windows") {
+    //println!("target: {}", target);
+    if host.contains("windows") && target.contains("windows-msvc") {
         let c = Command::new("cmake")
             .arg("-G")
             .arg("Visual Studio 16 2019")
@@ -103,26 +107,51 @@ fn main() {
         std::io::stderr().write_all(&m.stderr).unwrap();
         assert!(m.status.success());
     } else if target.contains("aarch64-apple-darwin") {
-        let c = Command::new("cmake")
-            .arg("-D")
-            .arg("ARCH=arm64")
-            .arg("-D")
-            .arg("ARCH_ID=aarch64")
-            .arg("-D")
-            .arg("CMAKE_CROSSCOMPILING=true")
-            .arg("-D")
-            .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
-            .arg("-D")
-            .arg("CMAKE_C_FLAGS='-arch arm64'")
-            .arg("-D")
-            .arg("CMAKE_CXX_FLAGS='-arch arm64'")
-            .arg(repo_dir.to_str().unwrap())
-            .output()
-            .expect("failed to execute CMake");
-        println!("status: {}", c.status);
-        std::io::stdout().write_all(&c.stdout).unwrap();
-        std::io::stderr().write_all(&c.stderr).unwrap();
-        assert!(c.status.success());
+        if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
+            let c = Command::new("cmake")
+                .arg("-D")
+                .arg("ARCH=arm64")
+                .arg("-D")
+                .arg("ARCH_ID=aarch64")
+                .arg("-D")
+                .arg("CMAKE_CROSSCOMPILING=true")
+                .arg("-D")
+                .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
+                .arg("-D")
+                .arg("CMAKE_C_FLAGS='-arch arm64'")
+                .arg("-D")
+                .arg("CMAKE_CXX_FLAGS='-arch arm64'")
+                .arg("-D")
+                .arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
+                .arg(repo_dir.to_str().unwrap())
+                .output()
+                .expect("failed to execute CMake");
+            println!("status: {}", c.status);
+            std::io::stdout().write_all(&c.stdout).unwrap();
+            std::io::stderr().write_all(&c.stderr).unwrap();
+            assert!(c.status.success());
+        } else {
+            let c = Command::new("cmake")
+                .arg("-D")
+                .arg("ARCH=arm64")
+                .arg("-D")
+                .arg("ARCH_ID=aarch64")
+                .arg("-D")
+                .arg("CMAKE_CROSSCOMPILING=true")
+                .arg("-D")
+                .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
+                .arg("-D")
+                .arg("CMAKE_C_FLAGS='-arch arm64'")
+                .arg("-D")
+                .arg("CMAKE_CXX_FLAGS='-arch arm64'")
+                .arg(repo_dir.to_str().unwrap())
+                .output()
+                .expect("failed to execute CMake");
+            println!("status: {}", c.status);
+            std::io::stdout().write_all(&c.stdout).unwrap();
+            std::io::stderr().write_all(&c.stderr).unwrap();
+            assert!(c.status.success());
+        }
 
         let m = Command::new("cmake")
             .arg("--build")
@@ -144,7 +173,10 @@ fn main() {
         std::io::stdout().write_all(&c.stdout).unwrap();
         std::io::stderr().write_all(&c.stderr).unwrap();
         assert!(c.status.success());
-        let m = Command::new("make").output().expect("failed to execute Make");
+
+        let m = Command::new("make")
+            .output()
+            .expect("failed to execute Make");
         println!("status: {}", m.status);
         std::io::stdout().write_all(&m.stdout).unwrap();
         std::io::stderr().write_all(&m.stderr).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -124,7 +124,7 @@ fn main() {
                 c = c.arg("-D")
                 .arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
                 };
-                c.arg(repo_dir.to_str().unwrap())
+                c = c.arg(repo_dir.to_str().unwrap())
                 .output()
                 .expect("failed to execute CMake");
             println!("status: {}", c.status);

--- a/build.rs
+++ b/build.rs
@@ -107,8 +107,8 @@ fn main() {
         std::io::stderr().write_all(&m.stderr).unwrap();
         assert!(m.status.success());
     } else if target.contains("aarch64-apple-darwin") {
-        let mut c = Command::new("cmake")
-            .arg("-D")
+        let mut c = Command::new("cmake");
+        c.arg("-D")
             .arg("ARCH=arm64")
             .arg("-D")
             .arg("ARCH_ID=aarch64")
@@ -121,16 +121,16 @@ fn main() {
             .arg("-D")
             .arg("CMAKE_CXX_FLAGS='-arch arm64'");
         if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
-            c = c.arg("-D").arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
-        };
-        c = c
+            c.arg("-D").arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str());
+        }
+        let output = c
             .arg(repo_dir.to_str().unwrap())
             .output()
             .expect("failed to execute CMake");
-        println!("status: {}", c.status);
-        std::io::stdout().write_all(&c.stdout).unwrap();
-        std::io::stderr().write_all(&c.stderr).unwrap();
-        assert!(c.status.success());
+        println!("status: {}", output.status);
+        std::io::stdout().write_all(&output.stdout).unwrap();
+        std::io::stderr().write_all(&output.stderr).unwrap();
+        assert!(output.status.success());
 
         let m = Command::new("cmake")
             .arg("--build")

--- a/build.rs
+++ b/build.rs
@@ -108,30 +108,29 @@ fn main() {
         assert!(m.status.success());
     } else if target.contains("aarch64-apple-darwin") {
         let mut c = Command::new("cmake")
-                .arg("-D")
-                .arg("ARCH=arm64")
-                .arg("-D")
-                .arg("ARCH_ID=aarch64")
-                .arg("-D")
-                .arg("CMAKE_CROSSCOMPILING=true")
-                .arg("-D")
-                .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
-                .arg("-D")
-                .arg("CMAKE_C_FLAGS='-arch arm64'")
-                .arg("-D")
-                .arg("CMAKE_CXX_FLAGS='-arch arm64'");
-                if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
-                c = c.arg("-D")
-                .arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
-                };
-                c = c.arg(repo_dir.to_str().unwrap())
-                .output()
-                .expect("failed to execute CMake");
-            println!("status: {}", c.status);
-            std::io::stdout().write_all(&c.stdout).unwrap();
-            std::io::stderr().write_all(&c.stderr).unwrap();
-            assert!(c.status.success());
-    
+            .arg("-D")
+            .arg("ARCH=arm64")
+            .arg("-D")
+            .arg("ARCH_ID=aarch64")
+            .arg("-D")
+            .arg("CMAKE_CROSSCOMPILING=true")
+            .arg("-D")
+            .arg("CMAKE_SYSTEM_PROCESSOR=aarch64")
+            .arg("-D")
+            .arg("CMAKE_C_FLAGS='-arch arm64'")
+            .arg("-D")
+            .arg("CMAKE_CXX_FLAGS='-arch arm64'");
+        if let Ok(env) = env::var("RANDOMX_RS_CMAKE_OSX_SYSROOT") {
+            c = c.arg("-D").arg("CMAKE_OSX_SYSROOT=".to_owned() + env.as_str())
+        };
+        c = c
+            .arg(repo_dir.to_str().unwrap())
+            .output()
+            .expect("failed to execute CMake");
+        println!("status: {}", c.status);
+        std::io::stdout().write_all(&c.stdout).unwrap();
+        std::io::stderr().write_all(&c.stderr).unwrap();
+        assert!(c.status.success());
 
         let m = Command::new("cmake")
             .arg("--build")

--- a/build.rs
+++ b/build.rs
@@ -47,9 +47,9 @@ fn main() {
     env::set_current_dir(build_dir).unwrap();
 
     let host = env::var("HOST").unwrap();
-    //println!("host: {}", host);
+    // println!("host: {}", host);
     let target = env::var("TARGET").unwrap();
-    //println!("target: {}", target);
+    // println!("target: {}", target);
     if host.contains("windows") && target.contains("windows-msvc") {
         let c = Command::new("cmake")
             .arg("-G")
@@ -174,9 +174,7 @@ fn main() {
         std::io::stderr().write_all(&c.stderr).unwrap();
         assert!(c.status.success());
 
-        let m = Command::new("make")
-            .output()
-            .expect("failed to execute Make");
+        let m = Command::new("make").output().expect("failed to execute Make");
         println!("status: {}", m.status);
         std::io::stdout().write_all(&m.stdout).unwrap();
         std::io::stderr().write_all(&m.stderr).unwrap();


### PR DESCRIPTION
Check for env ```RANDOMX_RS_CMAKE_OSX_SYSROOT``` and pass to cmake as ```cmake_osx_sysroot``` for ```aarch64-apple-darwin``` platform.

Assist with https://github.com/tari-project/randomx-rs/issues/48
