### PR TITLE
feat: leet target osx sysroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Install [Build Tools for Visual Studio 2019](https://visualstudio.microsoft.com/
 
 # Troubleshooting
 
-## MacOs
+## Mac/OSX
 
 If you're experiencing linker issues, or messages like
 
@@ -86,3 +86,27 @@ Try:
 - Does `which cc` report more than one binary? If so, uninstalling one of the clang compilers might help.
 - Upgrading cmake. `brew uninstall cmake && brew install cmake`
 - `cargo clean`
+
+On Apple ARM64 hardware and newer XCode releases, RandomX might fail the `randomx-tests`.
+```
+[83] Hash test 1e (interpreter)               ... PASSED
+[84] Hash test 2a (compiler)                  ... Assertion failed: (equalsHex(hash, "639183aae1bf4c9a35884cb46b09cad9175f04efd7684e7262a0ac1c2f0b4e3f")), function operator(), file tests.cpp, line 966.
+zsh: abort      ./randomx-tests
+```
+or
+```
+[88] Hash test 2e (compiler)                  ... PASSED
+[89] Cache initialization: SSSE3              ... SKIPPED
+[90] Cache initialization: AVX2               ... SKIPPED
+[91] Hash batch test                          ... Assertion failed: (equalsHex(hash3, "c36d4ed4191e617309867ed66a443be4075014e2b061bcdaf9ce7b721d2b77a8")), function operator(), file tests.cpp, line 1074.
+zsh: abort      ./randomx-tests
+```
+ Building using an older SDK might help. Find location of current SDKs with `xcrun --show-sdk-path`, then for example:
+```bash
+export RANDOMX_RS_CMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk"
+cargo build
+```
+Quick test with built binaries
+```bash
+find target -name randomx-tests -exec {} \;
+```

--- a/build.rs
+++ b/build.rs
@@ -123,17 +123,17 @@ fn main() {
 
         let android_sdk = env::var("ANDROID_SDK_ROOT").expect("ANDROID_SDK_ROOT variable not set");
 
-        let android_platform = env::var("ANDROID_PLATFORM").unwrap_or("android-26".to_owned());
+        let android_platform = env::var("ANDROID_PLATFORM").unwrap_or_else(|_| "android-26".to_owned());
         let android_cmake =
             env::var("ANDROID_CMAKE").unwrap_or(android_sdk.clone() + &"/cmake/3.22.1/bin/cmake".to_owned());
         let android_toolchain = env::var("ANDROID_CMAKE_TOOLCHAIN")
-            .unwrap_or(android_sdk.clone() + &"/ndk/22.1.7171670/build/cmake/android.toolchain.cmake".to_owned());
+            .unwrap_or(android_sdk + &"/ndk/22.1.7171670/build/cmake/android.toolchain.cmake".to_owned());
 
         let c = Command::new(android_cmake)
             .arg("-D")
             .arg("CMAKE_TOOLCHAIN_FILE=".to_owned() + &android_toolchain)
             .arg("-D")
-            .arg("ANDROID_ABI=".to_owned() + &android_abi)
+            .arg("ANDROID_ABI=".to_owned() + android_abi)
             .arg("-D")
             .arg("ANDROID_PLATFORM=".to_owned() + &android_platform)
             .arg(repo_dir.to_str().unwrap())
@@ -215,9 +215,7 @@ fn main() {
         println!("cargo:rustc-link-lib=static=randomx");
     } // link to RandomX
 
-    if target.contains("apple") {
-        println!("cargo:rustc-link-lib=dylib=c++");
-    } else if target.contains("android") {
+    if target.contains("apple") || target.contains("android") {
         println!("cargo:rustc-link-lib=dylib=c++");
     } else if target.contains("linux") {
         println!("cargo:rustc-link-lib=dylib=stdc++");


### PR DESCRIPTION
From @leet4tari: Add info about Apple ARM64 override


This PR supersedes #51 removing clippy warnings. I just couldn't push to the original branch/pr. 