### PR TITLE
fix: dataset initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ libc = "0.2.121"
 bitflags = "1.3.2"
 thiserror = "1.0.30"
 
+[dev-dependencies]
+hex = "0.4.3"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -22,6 +22,7 @@
 
 use libc::{c_uint, c_ulong, c_void};
 pub const RANDOMX_HASH_SIZE: u32 = 32;
+#[allow(dead_code)]
 pub const RANDOMX_DATASET_ITEM_SIZE: u32 = 64;
 
 #[repr(C)]

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -22,8 +22,6 @@
 
 use libc::{c_uint, c_ulong, c_void};
 pub const RANDOMX_HASH_SIZE: u32 = 32;
-#[allow(dead_code)]
-pub const RANDOMX_DATASET_ITEM_SIZE: u32 = 64;
 
 #[repr(C)]
 pub struct randomx_dataset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,4 +660,27 @@ mod tests {
         ]);
         drop(vm1);
     }
+
+    #[test]
+    fn randomx_hash_fast_vs_light() {
+        let input = b"input";
+        let key = b"key";
+
+        let cache = RandomXCache::new(RandomXFlag::FLAG_DEFAULT, key).unwrap();
+        let dataset = RandomXDataset::new(RandomXFlag::FLAG_DEFAULT, cache.clone(), 0).unwrap();
+        let fast_vm = RandomXVM::new(
+            RandomXFlag::FLAG_HARD_AES | RandomXFlag::FLAG_FULL_MEM,
+            Some(cache),
+            Some(dataset),
+        )
+        .unwrap();
+
+        let cache = RandomXCache::new(RandomXFlag::FLAG_DEFAULT, key).unwrap();
+        let dataset = RandomXDataset::new(RandomXFlag::FLAG_DEFAULT, cache.clone(), 0).unwrap();
+        let light_vm = RandomXVM::new(RandomXFlag::FLAG_HARD_AES, Some(cache), Some(dataset)).unwrap();
+
+        let fast = fast_vm.calculate_hash(input).unwrap();
+        let light = light_vm.calculate_hash(input).unwrap();
+        assert_eq!(fast, light);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,18 +662,14 @@ mod tests {
         let input = b"input";
         let key = b"key";
 
-        let cache = RandomXCache::new(RandomXFlag::FLAG_DEFAULT, key).unwrap();
-        let dataset = RandomXDataset::new(RandomXFlag::FLAG_DEFAULT, cache.clone(), 0).unwrap();
-        let fast_vm = RandomXVM::new(
-            RandomXFlag::FLAG_HARD_AES | RandomXFlag::FLAG_FULL_MEM,
-            Some(cache),
-            Some(dataset),
-        )
-        .unwrap();
+        let flags = RandomXFlag::get_recommended_flags() | RandomXFlag::FLAG_FULL_MEM;
+        let cache = RandomXCache::new(flags, key).unwrap();
+        let dataset = RandomXDataset::new(flags, cache, 0).unwrap();
+        let fast_vm = RandomXVM::new(flags, None, Some(dataset)).unwrap();
 
-        let cache = RandomXCache::new(RandomXFlag::FLAG_DEFAULT, key).unwrap();
-        let dataset = RandomXDataset::new(RandomXFlag::FLAG_DEFAULT, cache.clone(), 0).unwrap();
-        let light_vm = RandomXVM::new(RandomXFlag::FLAG_HARD_AES, Some(cache), Some(dataset)).unwrap();
+        let flags = RandomXFlag::get_recommended_flags();
+        let cache = RandomXCache::new(flags, key).unwrap();
+        let light_vm = RandomXVM::new(flags, Some(cache), None).unwrap();
 
         let fast = fast_vm.calculate_hash(input).unwrap();
         let light = light_vm.calculate_hash(input).unwrap();


### PR DESCRIPTION
Closes #54 

### Motivation
I looked over the tests in the RandomX C library and I found discrepancies in dataset initialization. [The docs say](https://github.com/tevador/RandomX/blob/040f4500a6e79d54d84a668013a94507045e786f/src/randomx.h#L150-L151):
> In order to use the Dataset, all items from 0 to (randomx_dataset_item_count() - 1) must be initialized.

In effect, all hashes calculated in _fast_ mode (`FLAG_FULL_MEM`) are invalid.
 
### Changes:
- added a few tests for hashing in both _light_ and _fast_ modes using the vectors borrowed from https://github.com/tevador/RandomX/blob/040f4500a6e79d54d84a668013a94507045e786f/src/tests/tests.cpp#L963-L985;
- fixed `RandomXDataset` initialization so that all `randomx_dataset_item_count()` items are initialized;
- changed `RandomXDataset::count()` into an associated function as it is only a wrapper over `randomx_dataset_item_count()` and it doesn't require an instance in order to be called.


