### PR TITLE
fix: mac builds and new release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.1](https://github.com/tari-project/randomx-rs/compare/v1.1.15...v1.2.1) (2023-08-30)
+
+### Bug Fixes
+
+* fix compile on windows ([#61](https://github.com/tari-project/randomx-rs/issues/61)) ([646c615](https://github.com/tari-project/randomx-rs/commit/646c6150a01659417a2cacd9f1db0a7e492bdf1d))
+
 ## [1.2.0](https://github.com/tari-project/randomx-rs/compare/v1.1.15...v1.2.0) (2023-08-22)
 ### Feature
 
-Update random-x core library to commit hash (901f8ef765e7c274852dcb4d477247fd6747a5b8)
+* update randomx ([#60](https://github.com/tari-project/randomx-rs/issues/60)) ([5300721](https://github.com/tari-project/randomx-rs/commit/530072139e09a86b7247831f66b6ac6991c729e6))
 
 ### [1.1.15](https://github.com/tari-project/randomx-rs/compare/v1.1.14...v1.1.15) (2023-05-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2018"
 build = "build.rs"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl RandomXDataset {
                 // This weirdness brought to you by c_ulong being different on Windows and Linux
                 #[cfg(target_os = "windows")]
                 return Ok(x);
-                #[cfg(target_os = "linux")]
+                #[cfg(not(target_os = "windows"))]
                 return Ok(u32::try_from(x)?);
             },
         }


### PR DESCRIPTION
Updates the version for a new release to 1.2.1 to include windows hotfix and fixes mac build as well