### PR TITLE
build: add freebsd support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -214,7 +214,7 @@ fn main() {
         println!("cargo:rustc-link-lib=static=randomx");
     } // link to RandomX
 
-    if target.contains("apple") || target.contains("android") {
+    if target.contains("apple") || target.contains("android") || target.contains("freebsd") {
         println!("cargo:rustc-link-lib=dylib=c++");
     } else if target.contains("linux") {
         println!("cargo:rustc-link-lib=dylib=stdc++");


### PR DESCRIPTION
Afaik, there's no reason not to support FreeBSD. This small patch seemingly adds support. 

I'm pretty unexposed to cargo, so any others on FreeBSD willing to test would be appreciated. Seems like tari is running fine on my end with a patched local copy of randomx-rs, but that's been the extent of my testing. Tested on rust/cargo 1.72.0

