### PR TITLE
feat: allow windows to build with either visual studio 2022 or visual studio 2019

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2018"
 build = "build.rs"
 

--- a/build.rs
+++ b/build.rs
@@ -52,16 +52,46 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     // println!("target: {}", target);
     if host.contains("windows") && target.contains("windows-msvc") {
-        let c = Command::new("cmake")
+        let mut err_1 = "".to_string();
+        let mut err_2 = "".to_string();
+        let mut err_3 = "".to_string();
+        let mut success = false;
+        if let Ok(val) = Command::new("cmake")
             .arg("-G")
-            .arg("Visual Studio 16 2019")
+            .arg("Visual Studio 17 2022")
             .arg(repo_dir.to_str().unwrap())
             .output()
-            .expect("failed to execute CMake");
-        println!("status: {}", c.status);
-        std::io::stdout().write_all(&c.stdout).unwrap();
-        std::io::stderr().write_all(&c.stderr).unwrap();
-        assert!(c.status.success());
+        {
+            if val.status.success() {
+                success = true;
+            } else {
+                err_1 = String::from_utf8_lossy(&val.stderr).to_string();
+            }
+        }
+        if !success {
+            println!("'Visual Studio 17 2022' not found, trying 'Visual Studio 16 2019'");
+            match Command::new("cmake")
+                .arg("-G")
+                .arg("Visual Studio 16 2019")
+                .arg(repo_dir.to_str().unwrap())
+                .output()
+            {
+                Ok(val) => {
+                    if val.status.success() {
+                        success = true;
+                    } else {
+                        err_2 = String::from_utf8_lossy(&val.stderr).to_string();
+                    }
+                },
+                Err(err) => err_3 = err.to_string(),
+            }
+        }
+        if !success {
+            panic!(
+                "CMake failed with either Visual Studio 2022 (\n{}\n) or 'Visual Studio 16 2019' (\n{}\n) or (\n{}\n)",
+                err_1, err_2, err_3
+            );
+        }
 
         let m = Command::new("cmake")
             .arg("--build")

--- a/build.rs
+++ b/build.rs
@@ -73,14 +73,12 @@ fn main() {
 
             // Remove all files (contents) from 'build_dir', but not 'build_dir' itself
             if let Ok(dir_list) = fs::read_dir(build_dir) {
-                for entry in dir_list {
-                    if let Ok(entry) = entry {
-                        let path = entry.path();
-                        if path.is_file() {
-                            let _unused = fs::remove_file(path);
-                        } else if path.is_dir() {
-                            let _unused = fs::remove_dir_all(path);
-                        }
+                for entry in dir_list.flatten() {
+                    let path = entry.path();
+                    if path.is_file() {
+                        let _unused = fs::remove_file(path);
+                    } else if path.is_dir() {
+                        let _unused = fs::remove_dir_all(path);
                     }
                 }
             }

--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,21 @@ fn main() {
         }
         if !success {
             println!("'Visual Studio 17 2022' not found, trying 'Visual Studio 16 2019'");
+
+            // Remove all files (contents) from 'build_dir', but not 'build_dir' itself
+            if let Ok(dir_list) = fs::read_dir(build_dir) {
+                for entry in dir_list {
+                    if let Ok(entry) = entry {
+                        let path = entry.path();
+                        if path.is_file() {
+                            let _unused = fs::remove_file(path);
+                        } else if path.is_dir() {
+                            let _unused = fs::remove_dir_all(path);
+                        }
+                    }
+                }
+            }
+
             match Command::new("cmake")
                 .arg("-G")
                 .arg("Visual Studio 16 2019")

--- a/build.rs
+++ b/build.rs
@@ -79,6 +79,8 @@ fn main() {
                         let _unused = fs::remove_file(path);
                     } else if path.is_dir() {
                         let _unused = fs::remove_dir_all(path);
+                    } else {
+                        // Nothing here
                     }
                 }
             }


### PR DESCRIPTION
Description
---
The build will now use either `Visual Studio 17 2022` or `Visual Studio 16 2019`, whichever environment is sourced. It is still up to the user to start a Visual Studio Developer command prompt and build from there.

Motivation and Context
---
The build was failing with newly created build environments, as Visual Studio 16 2019 is only available to prior Visual Studio subscribers.

XMRig now supports `Visual Studio 17 2022` as well.
![image](https://github.com/user-attachments/assets/d08a54c0-bcea-4c90-9031-2ddc16a335cb)

How Has This Been Tested?
---
It was built using both platforms.

What process can a PR reviewer use to test or verify this change?
---
Code review
Run the build

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
