### PR TITLE
chore(ci): fix windows build with rust 1.87.0 plus add additional ci test targets

### DIFF
--- a/.github/workflows/build_tests.json
+++ b/.github/workflows/build_tests.json
@@ -1,17 +1,17 @@
 [
   {
     "name": "linux-x86_64",
-    "runs-on": "ubuntu-20.04",
-    "rust": "nightly-2024-07-07",
+    "runs-on": "ubuntu-22.04",
+    "rust": "stable",
     "target": "x86_64-unknown-linux-gnu",
     "cross": false
   },
   {
     "name": "linux-arm64",
-    "runs-on": "ubuntu-latest",
+    "runs-on": "ubuntu-22.04-arm",
     "rust": "stable",
     "target": "aarch64-unknown-linux-gnu",
-    "cross": true
+    "cross": false
   },
   {
     "name": "linux-riscv64",
@@ -51,8 +51,26 @@
     "best_effort": true
   },
   {
-    "name": "windows-arm64",
+    "name": "windows-x64-2025",
+    "runs-on": "windows-2025",
+    "rust": "stable",
+    "target": "x86_64-pc-windows-msvc",
+    "cross": false,
+    "build_enabled": true,
+    "best_effort": true
+  },
+  {
+    "name": "windows-arm64-cross",
     "runs-on": "windows-latest",
+    "rust": "stable",
+    "target": "aarch64-pc-windows-msvc",
+    "cross": false,
+    "build_enabled": true,
+    "best_effort": true
+  },
+  {
+    "name": "windows-arm64",
+    "runs-on": "windows-11-arm",
     "rust": "stable",
     "target": "aarch64-pc-windows-msvc",
     "cross": false,
@@ -107,7 +125,7 @@
   {
     "name": "android-riscv64",
     "runs-on": "ubuntu-latest",
-    "rust": "nightly-2024-07-07",
+    "rust": "nightly",
     "target": "riscv64-linux-android",
     "cross": true,
     "build_enabled": true,

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -153,7 +153,7 @@ jobs:
         if: ${{ ( ! startsWith(github.ref, 'refs/tags/v') ) && ( ! matrix.builds.cross ) && ( env.CARGO_CACHE ) }}
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.builds.target }}
+          key: ${{ matrix.builds.runs-on }}-${{ matrix.builds.target }}-${{ matrix.builds.name }}
 
       - name: Install and setup cargo cross
         if: ${{ matrix.builds.cross }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. See [standa
 ## [1.4.0](https://github.com/tari-project/randomx-rs/compare/v1.3.2...v1.4.0) (2025-05-21)
 ### Feature
 
-* switch to cmake crate and support less hard coded build system
+* switch to cmake crate and support less hard-coded build system
 
 ## [1.3.2](https://github.com/tari-project/randomx-rs/compare/v1.3.1...v1.3.2) (2024-11-13)
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.0](https://github.com/tari-project/randomx-rs/compare/v1.3.2...v1.4.0) (2025-05-21)
+### Feature
+
+* switch to cmake crate and support less hard coded build system
+
+## [1.3.2](https://github.com/tari-project/randomx-rs/compare/v1.3.1...v1.3.2) (2024-11-13)
+### Feature
+
+* support windows builds with either visual studio 2022 or visual studio 2019
+
 ## [1.3.1](https://github.com/tari-project/randomx-rs/compare/v1.3.1...v1.3.0) (2024-10-07)
 ### Feature
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/randomx-rs"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2018"
 build = "build.rs"
 
@@ -16,8 +16,8 @@ build = "build.rs"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-bitflags = "1.3.2"
 libc = "0.2.121"
+bitflags = "1.3.2"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ quickcheck = "1"
 
 [build-dependencies]
 cmake = "0.1"
+
+[profile.release]
+lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 libc = "0.2.121"
 bitflags = "1.3.2"
-thiserror = "1.0.30"
+thiserror = "1.0.50"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/build.rs
+++ b/build.rs
@@ -33,9 +33,9 @@ fn main() {
     println!("cargo:rustc-link-lib=static=randomx");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("linux".to_string());
     let dylib_name = match target_os.as_str() {
-        "macos" | "ios" => "c++",  // macOS and iOS use "c++"
-        "windows" => "msvcrt",     // Use MSVC runtime on Windows
-        _ => "stdc++",             // Default for other systems (Linux, etc.)
+        "macos" | "ios" => "c++", // macOS and iOS use "c++"
+        "windows" => "msvcrt",    // Use MSVC runtime on Windows
+        _ => "stdc++",            // Default for other systems (Linux, etc.)
     };
     println!("cargo:rustc-link-lib=dylib={}", dylib_name);
 

--- a/build.rs
+++ b/build.rs
@@ -38,4 +38,8 @@ fn main() {
         _ => "stdc++",             // Default for other systems (Linux, etc.)
     };
     println!("cargo:rustc-link-lib=dylib={}", dylib_name);
+
+    if cfg!(target_os = "windows") {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,4 @@
 # only used for cargo fmt settings, repo should always compile on stable too
 [toolchain]
 channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Description
Fix windows build with rust 1.87.0 - linking with advapi32lib.
Add and update CI for native and new target builds for testing

Motivation and Context
Fix windows builds

How Has This Been Tested?
Builds all needed platforms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for linking against the "advapi32" system library on Windows targets.
  - Updated build system to use the cmake crate, reducing hard-coded dependencies.

- **Chores**
  - Expanded and updated CI build and test environments, including new Windows and Linux configurations and improved cache key scoping.
  - Updated Rust toolchain configuration to include rustfmt and clippy components.
  - Added the thiserror dependency.

- **Documentation**
  - Updated changelog with new release entries for recent features and Windows build support.

- **Refactor**
  - Bumped version to 1.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->