### PR TITLE
build.rs: search `/lib64` as well

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,8 @@ fn main() {
     let randomx_path = Config::new(env::var("RANDOMX_DIR").unwrap_or_else(|_| "RandomX".to_string()))
         .define("DARCH", "native")
         .build();
+
+    println!("cargo:rustc-link-search=native={}/lib64", randomx_path.display());
     println!("cargo:rustc-link-search=native={}/lib", randomx_path.display());
     println!("cargo:rustc-link-lib=static=randomx");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("linux".to_string());


### PR DESCRIPTION
Description
---
Search `/lib64` in `build.rs` in addition to `/lib`.

Motivation and Context
---
Building on Fedora needs `/lib64` specified instead of `/lib`, else a linking error like this occurs: https://github.com/Cuprate/cuprate/actions/runs/15330922254/job/43137221458#step:9:26.

How Has This Been Tested?
---
`cargo build` on Fedora 42 and Debian 12 before/after change.