### PR TITLE
build: fix freebsd support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,9 +33,9 @@ fn main() {
     println!("cargo:rustc-link-lib=static=randomx");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("linux".to_string());
     let dylib_name = match target_os.as_str() {
-        "macos" | "ios" => "c++", // macOS and iOS use "c++"
-        "windows" => "msvcrt",    // Use MSVC runtime on Windows
-        _ => "stdc++",            // Default for other systems (Linux, etc.)
+        "freebsd" | "macos" | "ios" => "c++", // FreeBSD, macOS and iOS use "c++"
+        "windows" => "msvcrt",                // Use MSVC runtime on Windows
+        _ => "stdc++",                        // Default for other systems (Linux, etc.)
     };
     println!("cargo:rustc-link-lib=dylib={}", dylib_name);
 


### PR DESCRIPTION
Description
---
30d94108391e232476e54f712985e4dd87675f11 removed FreeBSD support added in 666b41200598a9001f20b4c5f129003634dd0f01

This pr re-add FreeBSD as a target_os in build.rs

Motivation and Context
---
Broken build in FreeBSD

How Has This Been Tested?
---
`cargo build --release`

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
