### PR TITLE
chore(ci): bumped actions/checkout and remove windows-2019 runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,5 @@
 ---
-name: Security audit - daily
+name: Security audit - weekly
 
 'on':
   push:
@@ -13,7 +13,7 @@ name: Security audit - daily
       - '**/audit.toml'
   # Rerun periodicly to pick up new advisories
   schedule:
-    - cron: '43 05 * * *'
+    - cron: '43 05 * * 0'
   # Run manually
   workflow_dispatch:
 
@@ -24,7 +24,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: "true"
 

--- a/.github/workflows/build_tests.json
+++ b/.github/workflows/build_tests.json
@@ -35,13 +35,6 @@
     "cross": false
   },
   {
-    "name": "windows-x64-2019",
-    "runs-on": "windows-2019",
-    "rust": "stable",
-    "target": "x86_64-pc-windows-msvc",
-    "cross": false
-  },
-  {
     "name": "windows-x64-2022",
     "runs-on": "windows-2022",
     "rust": "stable",

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -6,9 +6,13 @@ name: Build Test Matrix
     tags:
       - "v[0-9]+.[0-9]+.[0-9]*"
     branches:
+      - "development"
       - "build-ci-*"
+  pull_request:
+    branches:
+      - "development"
   schedule:
-    - cron: "05 00 * * *"
+    - cron: "05 00 * * 0"
   workflow_dispatch:
 
 env:
@@ -34,7 +38,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
 
@@ -88,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: install ripgrep
         run: |
           # https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb.sha256
@@ -98,7 +98,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
 
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
 

--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "true"
 


### PR DESCRIPTION
Description
bumped actions/checkout
remove windows-2019 runner
schedule audit runs once a week

Motivation and Context
Updates and remove deprecated windows-2019 target

How Has This Been Tested?
Builds in local fork
